### PR TITLE
Fixed bump2version config, setting current_version pattern.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -18,3 +18,5 @@ values =
 first_value = 1
 
 [bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"


### PR DESCRIPTION
Added search value and replace value in the bumpversion config so that it only replaces version string pyproject.toml. 